### PR TITLE
Remove :unneeded as it has been deprecated

### DIFF
--- a/Formula/cloud-platform-cli.rb
+++ b/Formula/cloud-platform-cli.rb
@@ -7,7 +7,6 @@ class CloudPlatformCli < Formula
   homepage "https://user-guide.cloud-platform.service.justice.gov.uk/#cloud-platform-user-guide"
   version "1.12.6"
   license "MIT"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.arm?


### PR DESCRIPTION
Without this change the following warning is printed when upgrading/updating:

```bash
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the ministryofjustice/cloud-platform-tap tap (not Homebrew/brew or Homebrew/core):
  /opt/homebrew/Library/Taps/ministryofjustice/homebrew-cloud-platform-tap/Formula/cloud-platform-cli.rb:10
```

Note that bottle :unneeded was deprecated by homebrew-core in [June 2021](https://github.com/Homebrew/brew/pull/11239), and no longer has any meaning to the bottler.